### PR TITLE
add supportedBy field to network definitions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,4 @@ repos:
     hooks:
       - id: check-jsonschema
         files: ^config.*\.json$
-        args: ["--schemafile", "config-schema.json"]
+        args: ["--schemafile", "schema.json"]

--- a/config-dev.json
+++ b/config-dev.json
@@ -17,6 +17,11 @@
         "https://api.blockchain.info/eth/nodes/rpc"
       ],
       "shortName": "Ethereum",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "EVM"
     },
     {
@@ -36,6 +41,9 @@
         "https://api.blockchain.info/matic-bor/nodes/rpc"
       ],
       "shortName": "Polygon",
+      "supportedBy": [
+        "DEFI"
+      ],
       "type": "EVM"
     },
     {
@@ -55,6 +63,7 @@
         "https://api.blockchain.info/bnb/nodes/rpc"
       ],
       "shortName": "BSC",
+      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -74,6 +83,7 @@
         "https://api.blockchain.info/avax/nodes/rpc/ext/bc/C/rpc"
       ],
       "shortName": "Avalanche",
+      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -89,6 +99,11 @@
       "networkTicker": "BTC",
       "nodeUrls": [],
       "shortName": "Bitcoin",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "BTC"
     },
     {
@@ -104,6 +119,11 @@
       "networkTicker": "BCH",
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "BCH"
     },
     {
@@ -121,6 +141,10 @@
         "https://api.blockchain.info/stellar"
       ],
       "shortName": "Stellar",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "XLM"
     },
     {
@@ -138,6 +162,10 @@
         "https://ssc-dao.genesysgo.net/"
       ],
       "shortName": "Solana",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "SOL"
     },
     {
@@ -153,6 +181,10 @@
       "networkTicker": "STX",
       "nodeUrls": [],
       "shortName": "Stacks",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "STX"
     }
   ],

--- a/config-dev.json
+++ b/config-dev.json
@@ -18,9 +18,8 @@
       ],
       "shortName": "Ethereum",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "EVM"
     },
@@ -42,7 +41,8 @@
       ],
       "shortName": "Polygon",
       "supportedBy": [
-        "DEFI"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "EVM"
     },
@@ -100,9 +100,7 @@
       "nodeUrls": [],
       "shortName": "Bitcoin",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA"
       ],
       "type": "BTC"
     },
@@ -120,9 +118,7 @@
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA"
       ],
       "type": "BCH"
     },
@@ -142,8 +138,8 @@
       ],
       "shortName": "Stellar",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "XLM"
     },
@@ -163,8 +159,8 @@
       ],
       "shortName": "Solana",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "SOL"
     },
@@ -182,8 +178,8 @@
       "nodeUrls": [],
       "shortName": "Stacks",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "STX"
     }

--- a/config-staging.json
+++ b/config-staging.json
@@ -17,6 +17,11 @@
         "https://api.blockchain.info/eth/nodes/rpc"
       ],
       "shortName": "Ethereum",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "EVM"
     },
     {
@@ -36,6 +41,9 @@
         "https://api.blockchain.info/matic-bor/nodes/rpc"
       ],
       "shortName": "Polygon",
+      "supportedBy": [
+        "DEFI"
+      ],
       "type": "EVM"
     },
     {
@@ -55,6 +63,7 @@
         "https://api.blockchain.info/bnb/nodes/rpc"
       ],
       "shortName": "BSC",
+      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -74,6 +83,7 @@
         "https://api.blockchain.info/avax/nodes/rpc/ext/bc/C/rpc"
       ],
       "shortName": "Avalanche",
+      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -89,6 +99,11 @@
       "networkTicker": "BTC",
       "nodeUrls": [],
       "shortName": "Bitcoin",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "BTC"
     },
     {
@@ -104,6 +119,11 @@
       "networkTicker": "BCH",
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "BCH"
     },
     {
@@ -121,6 +141,10 @@
         "https://api.blockchain.info/stellar"
       ],
       "shortName": "Stellar",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "XLM"
     },
     {
@@ -138,6 +162,10 @@
         "https://ssc-dao.genesysgo.net/"
       ],
       "shortName": "Solana",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "SOL"
     },
     {
@@ -153,6 +181,10 @@
       "networkTicker": "STX",
       "nodeUrls": [],
       "shortName": "Stacks",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "STX"
     }
   ],

--- a/config-staging.json
+++ b/config-staging.json
@@ -18,9 +18,8 @@
       ],
       "shortName": "Ethereum",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "EVM"
     },
@@ -42,7 +41,8 @@
       ],
       "shortName": "Polygon",
       "supportedBy": [
-        "DEFI"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "EVM"
     },
@@ -100,9 +100,7 @@
       "nodeUrls": [],
       "shortName": "Bitcoin",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA"
       ],
       "type": "BTC"
     },
@@ -120,9 +118,7 @@
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA"
       ],
       "type": "BCH"
     },
@@ -142,8 +138,8 @@
       ],
       "shortName": "Stellar",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "XLM"
     },
@@ -163,8 +159,8 @@
       ],
       "shortName": "Solana",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "SOL"
     },
@@ -182,8 +178,8 @@
       "nodeUrls": [],
       "shortName": "Stacks",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "STX"
     }

--- a/config.json
+++ b/config.json
@@ -17,6 +17,11 @@
         "https://api.blockchain.info/eth/nodes/rpc"
       ],
       "shortName": "Ethereum",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "EVM"
     },
     {
@@ -36,6 +41,9 @@
         "https://api.blockchain.info/matic-bor/nodes/rpc"
       ],
       "shortName": "Polygon",
+      "supportedBy": [
+        "DEFI"
+      ],
       "type": "EVM"
     },
     {
@@ -55,6 +63,7 @@
         "https://api.blockchain.info/bnb/nodes/rpc"
       ],
       "shortName": "BSC",
+      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -74,6 +83,7 @@
         "https://api.blockchain.info/avax/nodes/rpc/ext/bc/C/rpc"
       ],
       "shortName": "Avalanche",
+      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -89,6 +99,11 @@
       "networkTicker": "BTC",
       "nodeUrls": [],
       "shortName": "Bitcoin",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "BTC"
     },
     {
@@ -104,6 +119,11 @@
       "networkTicker": "BCH",
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
+      "supportedBy": [
+        "DEFI",
+        "NATIVE",
+        "TRADING"
+      ],
       "type": "BCH"
     },
     {
@@ -121,6 +141,10 @@
         "https://api.blockchain.info/stellar"
       ],
       "shortName": "Stellar",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "XLM"
     },
     {
@@ -138,6 +162,10 @@
         "https://ssc-dao.genesysgo.net/"
       ],
       "shortName": "Solana",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "SOL"
     },
     {
@@ -153,6 +181,10 @@
       "networkTicker": "STX",
       "nodeUrls": [],
       "shortName": "Stacks",
+      "supportedBy": [
+        "DEFI",
+        "TRADING"
+      ],
       "type": "STX"
     }
   ],

--- a/config.json
+++ b/config.json
@@ -18,9 +18,8 @@
       ],
       "shortName": "Ethereum",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "EVM"
     },
@@ -42,7 +41,8 @@
       ],
       "shortName": "Polygon",
       "supportedBy": [
-        "DEFI"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "EVM"
     },
@@ -100,9 +100,7 @@
       "nodeUrls": [],
       "shortName": "Bitcoin",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA"
       ],
       "type": "BTC"
     },
@@ -120,9 +118,7 @@
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
       "supportedBy": [
-        "DEFI",
-        "NATIVE",
-        "TRADING"
+        "DSC_DATA"
       ],
       "type": "BCH"
     },
@@ -142,8 +138,8 @@
       ],
       "shortName": "Stellar",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "XLM"
     },
@@ -163,8 +159,8 @@
       ],
       "shortName": "Solana",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "SOL"
     },
@@ -182,8 +178,8 @@
       "nodeUrls": [],
       "shortName": "Stacks",
       "supportedBy": [
-        "DEFI",
-        "TRADING"
+        "DSC_DATA",
+        "DSC_TRANSACTIONS"
       ],
       "type": "STX"
     }

--- a/config.json
+++ b/config.json
@@ -17,10 +17,6 @@
         "https://api.blockchain.info/eth/nodes/rpc"
       ],
       "shortName": "Ethereum",
-      "supportedBy": [
-        "DSC_DATA",
-        "DSC_TRANSACTIONS"
-      ],
       "type": "EVM"
     },
     {
@@ -40,10 +36,6 @@
         "https://api.blockchain.info/matic-bor/nodes/rpc"
       ],
       "shortName": "Polygon",
-      "supportedBy": [
-        "DSC_DATA",
-        "DSC_TRANSACTIONS"
-      ],
       "type": "EVM"
     },
     {
@@ -63,7 +55,6 @@
         "https://api.blockchain.info/bnb/nodes/rpc"
       ],
       "shortName": "BSC",
-      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -83,7 +74,6 @@
         "https://api.blockchain.info/avax/nodes/rpc/ext/bc/C/rpc"
       ],
       "shortName": "Avalanche",
-      "supportedBy": [],
       "type": "EVM"
     },
     {
@@ -99,9 +89,6 @@
       "networkTicker": "BTC",
       "nodeUrls": [],
       "shortName": "Bitcoin",
-      "supportedBy": [
-        "DSC_DATA"
-      ],
       "type": "BTC"
     },
     {
@@ -117,9 +104,6 @@
       "networkTicker": "BCH",
       "nodeUrls": [],
       "shortName": "Bitcoin Cash",
-      "supportedBy": [
-        "DSC_DATA"
-      ],
       "type": "BCH"
     },
     {
@@ -137,10 +121,6 @@
         "https://api.blockchain.info/stellar"
       ],
       "shortName": "Stellar",
-      "supportedBy": [
-        "DSC_DATA",
-        "DSC_TRANSACTIONS"
-      ],
       "type": "XLM"
     },
     {
@@ -158,10 +138,6 @@
         "https://ssc-dao.genesysgo.net/"
       ],
       "shortName": "Solana",
-      "supportedBy": [
-        "DSC_DATA",
-        "DSC_TRANSACTIONS"
-      ],
       "type": "SOL"
     },
     {
@@ -177,10 +153,6 @@
       "networkTicker": "STX",
       "nodeUrls": [],
       "shortName": "Stacks",
-      "supportedBy": [
-        "DSC_DATA",
-        "DSC_TRANSACTIONS"
-      ],
       "type": "STX"
     }
   ],

--- a/schema.json
+++ b/schema.json
@@ -40,6 +40,12 @@
           "shortName": {
             "type": "string"
           },
+          "supportedBy": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "type": {
             "type": "string"
           }
@@ -55,7 +61,8 @@
           "networkTicker",
           "nodeUrls",
           "shortName",
-          "type"
+          "type",
+          "supportedBy"
         ],
         "type": "object"
       },


### PR DESCRIPTION
https://blockchain.atlassian.net/browse/CUST-571

Adding a `supportedBy` field to each network. This is an array of options.
* `DSC_DATA` means the network is supported by the unified balances and activity endpoints - this is required to support a network in the defi wallet
* `DSC_TRANSACTIONS` means the network is supported by the buildTx and pushTx transaction flows - if this isn't supported the clients must use native sdks for transactions