### PR TITLE
feat: sol non-native token fee currency

### DIFF
--- a/config-staging.json
+++ b/config-staging.json
@@ -239,7 +239,8 @@
       "coinApi": "sol",
       "explorerUrl": "https://explorer.solana.com/tx",
       "feeCurrencies": [
-        "native"
+        "native",
+        "token"
       ],
       "identifiers": {},
       "memos": true,


### PR DESCRIPTION
adds `token` as an available `feeCurrency` for Solana in `config-staging.json`